### PR TITLE
Fix bug with async options in flint test command

### DIFF
--- a/bin/commands/test.js
+++ b/bin/commands/test.js
@@ -62,12 +62,12 @@ Options:
                 } catch (e) {
                     reject(new Error(`Unable to find the adapter OPTIONS in order to run integration tests. Ensure that relative path the options are given: 'flint test ./relative/path/to/adapter --opt="./relative/path/to/opt.js'.`));
                 }
-            
+
                 if (!opt) {
                     throw `Adapter OPTIONS not found at ${path.join(process.cwd(), this.args.opt)}`
                 } else if (opt instanceof Promise) {
                     opt
-                        .then(realOpt => integration(Adapter, opt))
+                        .then(realOpt => integration(Adapter, realOpt))
                         .catch(err => {
                             reject(new Error("Error received while waiting for options promise to resolve."));
                         })


### PR DESCRIPTION
Previously, when returning a Promise for async options in
a flint-opt file, the Promise was passed to the adapter in its
opt function, rather than the resolved options object.