### PR TITLE
Fix integration-suite put tests for writing relationships and sets

### DIFF
--- a/bin/commands/integration-suite/suite/put.js
+++ b/bin/commands/integration-suite/suite/put.js
@@ -51,13 +51,13 @@ describe('Flint Integration Suite:', function() {
             $focus.put(focus.val);
             $ford.put(ford.val);
 
-            let $make = getGun().get(focusKey).get('make');
+            let $make = gun.get(focusKey).get('make');
             $make.put($ford);
 
             let target = Object.keys(ford.val).length;
             let finished = false;
             setTimeout(function() {
-                getGun().get(focusKey).get('make').on(make => {
+                gun.get(focusKey).get('make').on(make => {
                     delete make._;
                     if (!finished && Object.keys(make).length === target) {
                         assert.deepStrictEqual(make, ford.val);
@@ -96,11 +96,11 @@ describe('Flint Integration Suite:', function() {
             var vwTarget = Object.keys(vw.val).length;
             var bmwTarget = Object.keys(bmw.val).length;
 
-            let $manufacturers = getGun().get(germanyKey).get('manufacturers');
+            let $manufacturers = gun.get(germanyKey).get('manufacturers');
             $manufacturers.set($vw);
             $manufacturers.set($bmw);
             setTimeout(() => {
-                getGun().get(germanyKey).get('manufacturers').map().on((maker, key) => {
+                gun.get(germanyKey).get('manufacturers').map().on((maker, key) => {
                     delete maker._;
                     var makerPropCount = Object.keys(maker).length;
                     if (key === vwKey) {
@@ -120,7 +120,7 @@ describe('Flint Integration Suite:', function() {
                         done();
                     }
                 });
-            }, 500);        
+            }, 500);
         });
 
     });


### PR DESCRIPTION
The getGun() function appears to instantiate a new Gun instance each time it is called.
It is called in a beforeEach() block prior to each test and sets up the gun
variable with the instance.
However, in certain tests, getGun() is called separately midway through the test.
This looks to cause the test to try to assert data in a
different Gun instance than the data was written to prior in the test,
leading to a test failure.
Replacing the getGun() call in these tests with the gun variable instance
that was setup in the beforeEach block appears to fix the issue and make
the tests pass.